### PR TITLE
Add serverInfo and --version CLI arg

### DIFF
--- a/anakinls/__main__.py
+++ b/anakinls/__main__.py
@@ -1,7 +1,9 @@
 import argparse
+import inspect
 import logging
 
 from .server import server
+from .version import get_version
 
 logging.basicConfig(level=logging.INFO)
 logging.getLogger('pygls.protocol').setLevel(logging.WARN)
@@ -26,7 +28,21 @@ def main():
         help='Bind to this port'
     )
 
+    parser.add_argument(
+        '--version', action='store_true',
+        help='Print version and exit'
+    )
+
     args = parser.parse_args()
+
+    if args.version:
+        print(inspect.cleandoc(f'''anakinls v{get_version()}
+          Copyright (C) 2020 Andrii Kolomoiets
+          This is free software; see the source for copying conditions.
+          There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
+          PARTICULAR PURPOSE.
+        '''))
+        return
 
     if args.tcp:
         server.start_tcp(args.host, args.port)

--- a/anakinls/server.py
+++ b/anakinls/server.py
@@ -30,6 +30,7 @@ from pygls.server import LanguageServer
 from pygls.protocol import LanguageServerProtocol
 from pygls.uris import from_fs_path, to_fs_path
 
+from .version import get_version
 
 RE_WORD = re.compile(r'\w*')
 
@@ -106,6 +107,11 @@ class AnakinLanguageServerProtocol(LanguageServerProtocol):
             types.CodeActionKind.RefactorInline,
             types.CodeActionKind.RefactorExtract
         ])
+        # pygls does not currently support serverInfo of LSP v3.15
+        result.serverInfo = {
+            'name': 'anakinls',
+            'version': get_version(),
+        }
         return result
 
 

--- a/anakinls/version.py
+++ b/anakinls/version.py
@@ -1,0 +1,6 @@
+import pkg_resources
+
+def get_version() -> str:
+    "Return the version of anakinls."
+    r = pkg_resources.require('anakin-language-server')
+    return r[0].version


### PR DESCRIPTION
This helps Eglot to know which server it communicates with.

I haven't done this, but each file should contain the copyright blurb.  Please, make it GPLv3+ if you can. That is containing the "or (at your option) any later version" part.

I know I should have contributed a types.ServerInfo to pygls first, but I hope this is still OK for the time being. 

Also, Anakin was the bad buy, wasn't he?  Strange naming.  I liked the plugin architecture of pyls but it's good there's competition.  Good luck with this project!  