### PR TITLE
Do not report syntax errors from pyflakes

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pytest
         make install
     - name: Lint with pycodestyle and pyflakes
       run: |

--- a/anakinls/server.py
+++ b/anakinls/server.py
@@ -195,19 +195,9 @@ class PyflakesReporter:
     def _get_codeline(self, line):
         return self.script._code_lines[line].rstrip('\n\r')
 
-    def syntaxError(self, _filename, msg, lineno, offset, _text):
-        line = lineno - 1
-        col = offset or 0
-        self.result.append(types.Diagnostic(
-            range=types.Range(
-                start=types.Position(line=line, character=col),
-                end=types.Position(
-                    line=line,
-                    character=len(self._get_codeline(line)) - col)),
-            message=msg,
-            severity=types.DiagnosticSeverity.Error,
-            source='pyflakes'
-        ))
+    def syntaxError(self, *args, **kwargs):
+        # Syntax errors are provided by Jedi. Just ignore pyflakes.
+        pass
 
     def flake(self, message):
         line = message.lineno - 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pygls>=1.1,<1.2
 pyflakes~=2.2
 pycodestyle~=2.5
 yapf~=0.30
+
+pytest


### PR DESCRIPTION
Syntax errors are reported by Jedi, so there is no need to duplicate it